### PR TITLE
Pet Photo Filter

### DIFF
--- a/Petulia.xcodeproj/project.pbxproj
+++ b/Petulia.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		2C5862DE2628032600725D5E /* OrganizationResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C5862DD2628032600725D5E /* OrganizationResponse.swift */; };
 		2CE28716262EA5A0002D888A /* Petfinder-Info-Template.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2CE28715262EA5A0002D888A /* Petfinder-Info-Template.plist */; };
 		3F91B3792629043E00DAD14B /* OrganizationDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F91B3782629043E00DAD14B /* OrganizationDetailView.swift */; };
+		3FA4573F262F8F7400C789E9 /* Petfinder-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3FA4573E262F8F7400C789E9 /* Petfinder-Info.plist */; };
 		69263DE424E58B8B00EABF0E /* RoundedCorner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69263DE324E58B8B00EABF0E /* RoundedCorner.swift */; };
 		69263DE724E58BF300EABF0E /* View+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69263DE624E58BF300EABF0E /* View+Extension.swift */; };
 		695B34F224D6CA1500A15D26 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 695B34F124D6CA1500A15D26 /* AppDelegate.swift */; };
@@ -79,6 +80,7 @@
 		2C5862DD2628032600725D5E /* OrganizationResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrganizationResponse.swift; sourceTree = "<group>"; };
 		2CE28715262EA5A0002D888A /* Petfinder-Info-Template.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "Petfinder-Info-Template.plist"; path = "Petulia/Petfinder-Info-Template.plist"; sourceTree = "<group>"; };
 		3F91B3782629043E00DAD14B /* OrganizationDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrganizationDetailView.swift; sourceTree = "<group>"; };
+		3FA4573E262F8F7400C789E9 /* Petfinder-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Petfinder-Info.plist"; sourceTree = "<group>"; };
 		69263DE324E58B8B00EABF0E /* RoundedCorner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedCorner.swift; sourceTree = "<group>"; };
 		69263DE624E58BF300EABF0E /* View+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Extension.swift"; sourceTree = "<group>"; };
 		695B34EE24D6CA1500A15D26 /* Petulia.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Petulia.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -349,6 +351,7 @@
 				695B34F324D6CA1500A15D26 /* SceneDelegate.swift */,
 				695B34FF24D6CA2000A15D26 /* Info.plist */,
 				293B0C6E25DA5F5900A4DECB /* Petfinder-Info-Template.plist */,
+				3FA4573E262F8F7400C789E9 /* Petfinder-Info.plist */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -481,6 +484,7 @@
 				697E7D6D24E9528C0039EBF2 /* thanks.json in Resources */,
 				794E2CCA25AAF8CB00234FDA /* paws-preloader.json in Resources */,
 				695B34FB24D6CA2000A15D26 /* Preview Assets.xcassets in Resources */,
+				3FA4573F262F8F7400C789E9 /* Petfinder-Info.plist in Resources */,
 				794E2CCB25AAF8CB00234FDA /* cat-preloader.json in Resources */,
 				794E2CD125AAFE4100234FDA /* dots-preloader.json in Resources */,
 				695B34F824D6CA2000A15D26 /* Assets.xcassets in Resources */,

--- a/Petulia/Constants/Constants.swift
+++ b/Petulia/Constants/Constants.swift
@@ -14,6 +14,7 @@ enum Keys {
   // Theme
   static var prefferedAccentColor = "prefferedAccentColor"
   static var isDark = "isDark"
+  static var photoOnly = "photoOnly"
   
   // URLs
   static var baseURLPath = "api.petfinder.com"

--- a/Petulia/Theme/ThemeManager.swift
+++ b/Petulia/Theme/ThemeManager.swift
@@ -38,7 +38,7 @@ final class ThemeManager: ObservableObject {
   init() {
     loadAccentColor()
   }
-  
+
   func loadAccentColor() {
     if let loadedAccent = Color.color(from: prefferedAccentColor) {
       accentColor = loadedAccent

--- a/Petulia/ViewModels/OrganizationDataController.swift
+++ b/Petulia/ViewModels/OrganizationDataController.swift
@@ -30,7 +30,7 @@ final class OrganizationDataController: ObservableObject {
         let rawOrganizations = organizations.organizations
         self.allOrganizations = rawOrganizations.map { OrganizationDetailViewModel(model: $0)}
         // Print out all organizations
-        print(self.allOrganizations)
+//        print(self.allOrganizations)
       }
     }
   }

--- a/Petulia/ViewModels/PetDataController.swift
+++ b/Petulia/ViewModels/PetDataController.swift
@@ -68,20 +68,11 @@ final class PetDataController: ObservableObject {
   //MARK: - Private Methods
 
   func fetchResult(at endPoint: EndPoint) {
-    let defaults = UserDefaults.standard
-    let photo = defaults.bool(forKey:"photoOnly")
-    print("This is photos: \(photo)")
     isLoading = true
     apiService.fetch(at: endPoint) { [weak self]  (result: Result<AllAnimals, Error>) in
       switch result {
       case .success(let petData):
-        var rawPets = petData.animals ?? []
-        
-        // Enable this to show only pets with photos
-//        if photo == true{
-//          rawPets = rawPets.filter { $0.photos?.count != 0 }
-//        }
-        
+        let rawPets = petData.animals ?? []
         self?.allPets = rawPets.map { PetDetailViewModel(model: $0)}
         self?.pagination = petData.pagination
       case .failure( let error):

--- a/Petulia/ViewModels/PetDataController.swift
+++ b/Petulia/ViewModels/PetDataController.swift
@@ -78,9 +78,9 @@ final class PetDataController: ObservableObject {
         var rawPets = petData.animals ?? []
         
         // Enable this to show only pets with photos
-        if photo == true{
-          rawPets = rawPets.filter { $0.photos?.count != 0 }
-        }
+//        if photo == true{
+//          rawPets = rawPets.filter { $0.photos?.count != 0 }
+//        }
         
         self?.allPets = rawPets.map { PetDetailViewModel(model: $0)}
         self?.pagination = petData.pagination

--- a/Petulia/ViewModels/PetDataController.swift
+++ b/Petulia/ViewModels/PetDataController.swift
@@ -68,6 +68,9 @@ final class PetDataController: ObservableObject {
   //MARK: - Private Methods
 
   func fetchResult(at endPoint: EndPoint) {
+    let defaults = UserDefaults.standard
+    let photo = defaults.bool(forKey:"photoOnly")
+    print("This is photos: \(photo)")
     isLoading = true
     apiService.fetch(at: endPoint) { [weak self]  (result: Result<AllAnimals, Error>) in
       switch result {
@@ -75,7 +78,9 @@ final class PetDataController: ObservableObject {
         var rawPets = petData.animals ?? []
         
         // Enable this to show only pets with photos
-//        rawPets = rawPets.filter { $0.photos?.count != 0 }
+        if photo == true{
+          rawPets = rawPets.filter { $0.photos?.count != 0 }
+        }
         
         self?.allPets = rawPets.map { PetDetailViewModel(model: $0)}
         self?.pagination = petData.pagination

--- a/Petulia/Views/Home/HomeView.swift
+++ b/Petulia/Views/Home/HomeView.swift
@@ -22,7 +22,7 @@ struct HomeView: View {
   @State private var showSettingsSheet = false
   
   private var filteredPets: [PetDetailViewModel] {
-    if photoOnly == true{
+    if photoOnly == true {
       return petDataController.allPets.filter { $0.photos.count != 0 }
     }
     return petDataController.allPets

--- a/Petulia/Views/Home/HomeView.swift
+++ b/Petulia/Views/Home/HomeView.swift
@@ -16,10 +16,15 @@ struct HomeView: View {
   @AppStorage(Keys.savedPostcode) var postcode = ""
   @AppStorage(Keys.isDark) var isDark = false
   
+  @AppStorage(Keys.photoOnly) var photoOnly = false
+  
   @State private var typing = false
   @State private var showSettingsSheet = false
   
   private var filteredPets: [PetDetailViewModel] {
+    if photoOnly == true{
+      return petDataController.allPets.filter { $0.photos.count != 0 }
+    }
     return petDataController.allPets
   }
 

--- a/Petulia/Views/Settings/SettingsView.swift
+++ b/Petulia/Views/Settings/SettingsView.swift
@@ -20,8 +20,9 @@ struct SettingsView: View {
   @State private var typing = false
   
   @State private var accent = Color.pink
-  @AppStorage(Keys.photoOnly) var photoOnly = false
   @State private var showColorPicker = false
+  
+  @AppStorage(Keys.photoOnly) var photoOnly = false
   
   var body: some View {
     ZStack (alignment: .bottom) {
@@ -103,7 +104,7 @@ private extension SettingsView {
       Text("Show Photo Only")
       Spacer()
       ZStack {
-        Toggle("Show welcome message", isOn: $photoOnly)
+        Toggle("Show Photos", isOn: $photoOnly)
       }
       .frame(maxWidth: 30,maxHeight: 35)
       

--- a/Petulia/Views/Settings/SettingsView.swift
+++ b/Petulia/Views/Settings/SettingsView.swift
@@ -20,6 +20,7 @@ struct SettingsView: View {
   @State private var typing = false
   
   @State private var accent = Color.pink
+  @AppStorage(Keys.photoOnly) var photoOnly = false
   @State private var showColorPicker = false
   
   var body: some View {
@@ -31,6 +32,7 @@ struct SettingsView: View {
         VStack {
           Form {
             resultSessionView()
+            filterSessionView()
             themeSessionView()
             aboutSessionView()
           }
@@ -94,6 +96,19 @@ private extension SettingsView {
       .disableAutocorrection(true)
       
     }
+  }
+  
+  func filterSessionView() -> some View {
+    HStack {
+      Text("Show Photo Only")
+      Spacer()
+      ZStack {
+        Toggle("Show welcome message", isOn: $photoOnly)
+      }
+      .frame(maxWidth: 30,maxHeight: 35)
+      
+    }
+    .contentShape(Rectangle())
   }
   
   func themeSessionView() -> some View {


### PR DESCRIPTION
# Pet Photo Filter

Added an option to settings which allows the user to filter out the profiles which have no pet photo attached to them. Dynamically updates in real time after being pressed. It must be noted, that it simply changes the items displayed, and should the first group of pets not have photos at all, it will appear as none are there, but if you go into see all, you will be able to page and see that there are results there.

Fixes # 1

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Run in simulator and changed the settings multiple times.

- [x] Test A

**Test Configuration**:
* Firmware version:
* Hardware: Mac Book Pro 2016
* Toolchain: Simulator (?)
* SDK: Xcode

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

#Notes!
This does change the pets that appear to only display the ones with photos, but the ones without still exist as part of the request. The pet section view also does not fill in, but will simply only display the ones that would have had images. This will need to be updated in future so that instead of simply filtering out the ones we can see, it will filter in the call.