### PR TITLE
Added MapKit View to Pet Details

### DIFF
--- a/Petulia.xcodeproj/project.pbxproj
+++ b/Petulia.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		6983153D24E853B600E1566A /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6983153C24E853B600E1566A /* HomeView.swift */; };
 		69E4432124E87AC300B8B3F1 /* ListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69E4432024E87AC300B8B3F1 /* ListView.swift */; };
 		69E4432524E8820C00B8B3F1 /* PetDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69E4432424E8820C00B8B3F1 /* PetDetailViewModel.swift */; };
+		7752F6AB2638C5EA005D1C96 /* Petfinder-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 7752F6AA2638C5E9005D1C96 /* Petfinder-Info.plist */; };
 		7905B2182577A27700A55F37 /* HTMLText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7905B2172577A27700A55F37 /* HTMLText.swift */; };
 		7905B21B2577AC1F00A55F37 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7905B21A2577AC1F00A55F37 /* String+Extension.swift */; };
 		791F4E432581F9A000C5F457 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791F4E422581F9A000C5F457 /* SettingsView.swift */; };
@@ -103,6 +104,7 @@
 		6983153C24E853B600E1566A /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		69E4432024E87AC300B8B3F1 /* ListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListView.swift; sourceTree = "<group>"; };
 		69E4432424E8820C00B8B3F1 /* PetDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PetDetailViewModel.swift; sourceTree = "<group>"; };
+		7752F6AA2638C5E9005D1C96 /* Petfinder-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Petfinder-Info.plist"; sourceTree = "<group>"; };
 		7905B2172577A27700A55F37 /* HTMLText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTMLText.swift; sourceTree = "<group>"; };
 		7905B21A2577AC1F00A55F37 /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
 		791F4E422581F9A000C5F457 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
@@ -358,9 +360,8 @@
 				695B34F124D6CA1500A15D26 /* AppDelegate.swift */,
 				695B34F324D6CA1500A15D26 /* SceneDelegate.swift */,
 				695B34FF24D6CA2000A15D26 /* Info.plist */,
-				2C07138E26313289004168A2 /* Petfinder-Info.plist */,
+				7752F6AA2638C5E9005D1C96 /* Petfinder-Info.plist */,
 				293B0C6E25DA5F5900A4DECB /* Petfinder-Info-Template.plist */,
-				2C03308E2631E00C00961998 /* Petfinder-Info.plist */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -495,6 +496,7 @@
 				697E7D6D24E9528C0039EBF2 /* thanks.json in Resources */,
 				794E2CCA25AAF8CB00234FDA /* paws-preloader.json in Resources */,
 				695B34FB24D6CA2000A15D26 /* Preview Assets.xcassets in Resources */,
+				7752F6AB2638C5EA005D1C96 /* Petfinder-Info.plist in Resources */,
 				794E2CCB25AAF8CB00234FDA /* cat-preloader.json in Resources */,
 				794E2CD125AAFE4100234FDA /* dots-preloader.json in Resources */,
 				695B34F824D6CA2000A15D26 /* Assets.xcassets in Resources */,

--- a/Petulia.xcodeproj/project.pbxproj
+++ b/Petulia.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		3F0A05F22638CCB1000A55A1 /* OrgSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F0A05F12638CCB1000A55A1 /* OrgSectionView.swift */; };
 		3F0A05F62638CD20000A55A1 /* OrgPetListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F0A05F52638CD20000A55A1 /* OrgPetListView.swift */; };
 		3F91B3792629043E00DAD14B /* OrganizationDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F91B3782629043E00DAD14B /* OrganizationDetailView.swift */; };
+		3F96BA58263B6612008FC8C7 /* MapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F96BA57263B6612008FC8C7 /* MapView.swift */; };
 		69263DE424E58B8B00EABF0E /* RoundedCorner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69263DE324E58B8B00EABF0E /* RoundedCorner.swift */; };
 		69263DE724E58BF300EABF0E /* View+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69263DE624E58BF300EABF0E /* View+Extension.swift */; };
 		695B34F224D6CA1500A15D26 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 695B34F124D6CA1500A15D26 /* AppDelegate.swift */; };
@@ -89,6 +90,7 @@
 		3F0A05F12638CCB1000A55A1 /* OrgSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgSectionView.swift; sourceTree = "<group>"; };
 		3F0A05F52638CD20000A55A1 /* OrgPetListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgPetListView.swift; sourceTree = "<group>"; };
 		3F91B3782629043E00DAD14B /* OrganizationDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrganizationDetailView.swift; sourceTree = "<group>"; };
+		3F96BA57263B6612008FC8C7 /* MapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapView.swift; sourceTree = "<group>"; };
 		69263DE324E58B8B00EABF0E /* RoundedCorner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedCorner.swift; sourceTree = "<group>"; };
 		69263DE624E58BF300EABF0E /* View+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Extension.swift"; sourceTree = "<group>"; };
 		695B34EE24D6CA1500A15D26 /* Petulia.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Petulia.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -179,6 +181,7 @@
 			children = (
 				3F0A05F12638CCB1000A55A1 /* OrgSectionView.swift */,
 				3F0A05F52638CD20000A55A1 /* OrgPetListView.swift */,
+				3F96BA57263B6612008FC8C7 /* MapView.swift */,
 			);
 			path = Extras;
 			sourceTree = "<group>";
@@ -568,6 +571,7 @@
 				CF929FE2262E3EA100AE886C /* SnapCarousel.swift in Sources */,
 				69263DE724E58BF300EABF0E /* View+Extension.swift in Sources */,
 				7926ABDE256CE48800AD8D68 /* AsyncImageView.swift in Sources */,
+				3F96BA58263B6612008FC8C7 /* MapView.swift in Sources */,
 				797A0ECD25ACA8B900E40F9E /* FilterBarView.swift in Sources */,
 				CF929FD9262E2D4D00AE886C /* OrganizationScrollView.swift in Sources */,
 				6983153D24E853B600E1566A /* HomeView.swift in Sources */,
@@ -723,7 +727,7 @@
 				CURRENT_PROJECT_VERSION = 2;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"Petulia/Preview Content\"";
-				DEVELOPMENT_TEAM = HXYM5H2DXG;
+				DEVELOPMENT_TEAM = 6VH946FT2M;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = Petulia/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -746,7 +750,7 @@
 				CURRENT_PROJECT_VERSION = 2;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"Petulia/Preview Content\"";
-				DEVELOPMENT_TEAM = HXYM5H2DXG;
+				DEVELOPMENT_TEAM = 6VH946FT2M;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = Petulia/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/Petulia/Models/PetResponse.swift
+++ b/Petulia/Models/PetResponse.swift
@@ -94,12 +94,15 @@ struct Photo: Codable {
 struct Contact: Codable{
   var email: String?
   var phone: String?
+  var address: Address?
   
   enum CodingKeys: String, CodingKey {
     case email = "email"
     case phone = "phone"
+    case address
   }
 }
+
 
 enum Size: String, Codable {
   case small, medium, large, full

--- a/Petulia/ViewModels/PetDataController.swift
+++ b/Petulia/ViewModels/PetDataController.swift
@@ -75,15 +75,6 @@ final class PetDataController: ObservableObject {
         let rawPets = petData.animals ?? []
         self?.allPets = rawPets.map { PetDetailViewModel(model: $0)}
         self?.pagination = petData.pagination
-        let addressVar = self!.allPets.first?.contact
-        let petLocationAddress = addressVar?.address?.address1
-        // pet location address variable ✅
-        /// Pass address to detailView 
-        guard let petAddy = petLocationAddress else {
-          print("Pet location is nil @ fetch ")
-          return
-        }
-        print("Pet Location Address: \(petAddy)")
       case .failure( let error):
         print(error.localizedDescription)
       }

--- a/Petulia/ViewModels/PetDataController.swift
+++ b/Petulia/ViewModels/PetDataController.swift
@@ -75,6 +75,15 @@ final class PetDataController: ObservableObject {
         let rawPets = petData.animals ?? []
         self?.allPets = rawPets.map { PetDetailViewModel(model: $0)}
         self?.pagination = petData.pagination
+        let addressVar = self!.allPets.first?.contact
+        let petLocationAddress = addressVar?.address?.address1
+        // pet location address variable ✅
+        /// Pass address to detailView 
+        guard let petAddy = petLocationAddress else {
+          print("Pet location is nil @ fetch ")
+          return
+        }
+        print("Pet Location Address: \(petAddy)")
       case .failure( let error):
         print(error.localizedDescription)
       }

--- a/Petulia/ViewModels/PetDetailViewModel.swift
+++ b/Petulia/ViewModels/PetDetailViewModel.swift
@@ -29,6 +29,8 @@ struct PetDetailViewModel: Identifiable, Hashable, Codable {
   var shelterId: String
   var postedDate: String
   
+  
+  
   init(model: Animal) {
     self.id = model.id
     self.name = model.name ?? "Pet Name"
@@ -40,7 +42,9 @@ struct PetDetailViewModel: Identifiable, Hashable, Codable {
     self.tags = model.tags ?? []
     self.attributes = model.attributes?.list ?? [String: Bool]()
     self.description = model.description ?? "Your next beautiful, loving pet"
-    self.contact = model.contact ?? Contact(email: "No Mail", phone: "No Phone")
+    let addressHere = model.contact?.address ?? Address(address1: "Test", address2: "test", city: "test", state: "test", postcode: "test", country: "sdf")
+    
+    self.contact = model.contact ?? Contact(email: "No Mail", phone: "No Phone", address: addressHere)
     self.photos = model.photos ?? []
     self.gender = model.gender ?? "Unknown"
     self.status = model.status ?? "Unknown"

--- a/Petulia/ViewModels/PetDetailViewModel.swift
+++ b/Petulia/ViewModels/PetDetailViewModel.swift
@@ -30,7 +30,6 @@ struct PetDetailViewModel: Identifiable, Hashable, Codable {
   var postedDate: String
   
   
-  
   init(model: Animal) {
     self.id = model.id
     self.name = model.name ?? "Pet Name"
@@ -42,9 +41,7 @@ struct PetDetailViewModel: Identifiable, Hashable, Codable {
     self.tags = model.tags ?? []
     self.attributes = model.attributes?.list ?? [String: Bool]()
     self.description = model.description ?? "Your next beautiful, loving pet"
-    let addressHere = model.contact?.address ?? Address(address1: "Test", address2: "test", city: "test", state: "test", postcode: "test", country: "sdf")
-    
-    self.contact = model.contact ?? Contact(email: "No Mail", phone: "No Phone", address: addressHere)
+    self.contact = model.contact ?? Contact(email: "No Mail", phone: "No Phone")
     self.photos = model.photos ?? []
     self.gender = model.gender ?? "Unknown"
     self.status = model.status ?? "Unknown"

--- a/Petulia/Views/DetailUI/Extras/MapView.swift
+++ b/Petulia/Views/DetailUI/Extras/MapView.swift
@@ -1,0 +1,68 @@
+//
+//  MapView.swift
+//  Petulia
+//
+//  Created by Henry Calderon on 4/29/21.
+//  Copyright © 2021 Johandre Delgado . All rights reserved.
+//
+
+import SwiftUI
+import MapKit
+
+struct MapView: UIViewRepresentable {
+  var address: String
+  @State private var coordinate = CLLocationCoordinate2D()
+    
+    func makeUIView(context: Context) -> MKMapView {
+        MKMapView(frame: .zero)
+    }
+  
+  func updateUIView(_ view: MKMapView, context: Context) {
+    coordinates(forAddress: address){
+      (location) in
+      guard let location = location else {
+        // Handle error here.
+        return
+      }
+      coordinate = location
+      //      openMapForPlace(lat: location.latitude, long: location.longitude)
+    }
+    let span = MKCoordinateSpan(latitudeDelta: 2.0, longitudeDelta: 2.0)
+    let region = MKCoordinateRegion(center: coordinate, span: span)
+    //      let setRegion =
+    view.setRegion(region, animated: true)
+  }
+}
+
+struct MapView_Previews: PreviewProvider {
+    static var previews: some View {
+        MapView(address: "Redwood City")
+    }
+}
+
+extension MapView{
+  func coordinates(forAddress address: String, completion: @escaping (CLLocationCoordinate2D?) -> Void) {
+    let geocoder = CLGeocoder()
+    geocoder.geocodeAddressString(address) {
+      (place, error) in
+      guard error == nil else {
+        print("Geocoding error: \(error!)")
+        completion(nil)
+        return
+      }
+      completion(place?.first?.location?.coordinate)
+    }
+  }
+  
+//  coordinates(forAddress: "YOUR ADDRESS") {
+//    (location) in
+//    guard let location = location else {
+//      // Handle error here.
+//      return
+//    }
+//    coordinate = location
+//    //      openMapForPlace(lat: location.latitude, long: location.longitude)
+//  }
+  
+  
+}

--- a/Petulia/Views/DetailUI/Extras/MapView.swift
+++ b/Petulia/Views/DetailUI/Extras/MapView.swift
@@ -26,10 +26,8 @@ struct MapView: UIViewRepresentable {
       }
       coordinate = location
     }
-    
-    let span = MKCoordinateSpan(latitudeDelta: 2.0, longitudeDelta: 2.0)
+    let span = MKCoordinateSpan(latitudeDelta: 1.0, longitudeDelta: 1.0)
     let region = MKCoordinateRegion(center: coordinate, span: span)
-    //      let setRegion =
     view.setRegion(region, animated: true)
   }
 }

--- a/Petulia/Views/DetailUI/Extras/MapView.swift
+++ b/Petulia/Views/DetailUI/Extras/MapView.swift
@@ -25,8 +25,8 @@ struct MapView: UIViewRepresentable {
         return
       }
       coordinate = location
-      //      openMapForPlace(lat: location.latitude, long: location.longitude)
     }
+    
     let span = MKCoordinateSpan(latitudeDelta: 2.0, longitudeDelta: 2.0)
     let region = MKCoordinateRegion(center: coordinate, span: span)
     //      let setRegion =

--- a/Petulia/Views/DetailUI/PetDetailView.swift
+++ b/Petulia/Views/DetailUI/PetDetailView.swift
@@ -80,8 +80,8 @@ private extension PetDetailView {
   func stretchingHeroView() -> some View {
     StretchingHeader {
       ZStack(alignment: .bottom) {
-        if let city = viewModel.contact.address?.city{
-          MapView(address: city)
+        if let code = viewModel.contact.address?.postcode{
+          MapView(address: code)
         }else{
           LinearGradient(
             gradient: Gradient(colors: [Color.accentColor, Color.accentColor.opacity(0.8)]),

--- a/Petulia/Views/DetailUI/PetDetailView.swift
+++ b/Petulia/Views/DetailUI/PetDetailView.swift
@@ -9,6 +9,7 @@
 import SwiftUI
 import Foundation
 import MessageUI
+import MapKit
 
 struct PetDetailView: View{
   
@@ -102,6 +103,16 @@ private extension PetDetailView {
       }
     }
     .frame(height: 320)
+  }
+  
+  func makeUIView(context: Context) -> MKMapView {
+      MKMapView(frame: .zero)
+  }
+  func updateUIView(_ view: MKMapView, context: Context) {
+      let coordinate = CLLocationCoordinate2D(latitude: 37.4852, longitude: -122.2364)
+      let span = MKCoordinateSpan(latitudeDelta: 2.0, longitudeDelta: 2.0)
+      let region = MKCoordinateRegion(center: coordinate, span: span)
+      view.setRegion(region, animated: true)
   }
   
   func favoriteBar() -> some View {

--- a/Petulia/Views/DetailUI/PetDetailView.swift
+++ b/Petulia/Views/DetailUI/PetDetailView.swift
@@ -80,13 +80,15 @@ private extension PetDetailView {
   func stretchingHeroView() -> some View {
     StretchingHeader {
       ZStack(alignment: .bottom) {
-//        LinearGradient(
-//          gradient: Gradient(colors: [Color.accentColor, Color.accentColor.opacity(0.8)]),
-//          startPoint: .bottom,
-//          endPoint: .top
-//        )
-        
-        MapView(address: "New York City")
+        if let city = viewModel.contact.address?.city{
+          MapView(address: city)
+        }else{
+          LinearGradient(
+            gradient: Gradient(colors: [Color.accentColor, Color.accentColor.opacity(0.8)]),
+            startPoint: .bottom,
+            endPoint: .top
+          )
+        }
         
         favoriteBar()
           .offset(y: 40)

--- a/Petulia/Views/DetailUI/PetDetailView.swift
+++ b/Petulia/Views/DetailUI/PetDetailView.swift
@@ -33,7 +33,10 @@ struct PetDetailView: View{
   var body: some View {
     ScrollView(.vertical, showsIndicators: false) {
       VStack {
+        
+        
         stretchingHeroView()
+        
         
         VStack(alignment: .leading) {
           HStack {
@@ -77,11 +80,13 @@ private extension PetDetailView {
   func stretchingHeroView() -> some View {
     StretchingHeader {
       ZStack(alignment: .bottom) {
-        LinearGradient(
-          gradient: Gradient(colors: [Color.accentColor, Color.accentColor.opacity(0.8)]),
-          startPoint: .bottom,
-          endPoint: .top
-        )
+//        LinearGradient(
+//          gradient: Gradient(colors: [Color.accentColor, Color.accentColor.opacity(0.8)]),
+//          startPoint: .bottom,
+//          endPoint: .top
+//        )
+        
+        MapView(address: "Redwood City")
         
         favoriteBar()
           .offset(y: 40)
@@ -103,16 +108,6 @@ private extension PetDetailView {
       }
     }
     .frame(height: 320)
-  }
-  
-  func makeUIView(context: Context) -> MKMapView {
-      MKMapView(frame: .zero)
-  }
-  func updateUIView(_ view: MKMapView, context: Context) {
-      let coordinate = CLLocationCoordinate2D(latitude: 37.4852, longitude: -122.2364)
-      let span = MKCoordinateSpan(latitudeDelta: 2.0, longitudeDelta: 2.0)
-      let region = MKCoordinateRegion(center: coordinate, span: span)
-      view.setRegion(region, animated: true)
   }
   
   func favoriteBar() -> some View {
@@ -298,6 +293,7 @@ extension PetDetailView {
     
     vc?.present(composeVC, animated: true)
   }
+  
 }
 
 // MARK: - PREVIEWS

--- a/Petulia/Views/DetailUI/PetDetailView.swift
+++ b/Petulia/Views/DetailUI/PetDetailView.swift
@@ -86,7 +86,7 @@ private extension PetDetailView {
 //          endPoint: .top
 //        )
         
-        MapView(address: "Redwood City")
+        MapView(address: "New York City")
         
         favoriteBar()
           .offset(y: 40)

--- a/Resources/Resources.md
+++ b/Resources/Resources.md
@@ -9,3 +9,7 @@ Documents & links used to help build project
 
 #### Phone
 [Phone Call Help](https://stackoverflow.com/questions/60398122/how-to-make-phone-call-with-swiftui)
+
+#### MapKit - For a Specific Address
+[CLGeocoder](https://stackoverflow.com/questions/43918842/open-map-in-a-given-address-using-mapkit-and-swift)
+[Advanced MapKit](https://www.hackingwithswift.com/books/ios-swiftui/advanced-mkmapview-with-swiftui)

--- a/Resources/Resources.md
+++ b/Resources/Resources.md
@@ -1,6 +1,9 @@
 # Resources
 Documents & links used to help build project
 
+## Pull Requests
+Pull Request Format[here](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)
+
 ## Email & Phone
 
 #### Email
@@ -10,6 +13,6 @@ Documents & links used to help build project
 #### Phone
 [Phone Call Help](https://stackoverflow.com/questions/60398122/how-to-make-phone-call-with-swiftui)
 
-#### MapKit - For a Specific Address
+## MapKit - For a Specific Address
 [CLGeocoder](https://stackoverflow.com/questions/43918842/open-map-in-a-given-address-using-mapkit-and-swift)
 [Advanced MapKit](https://www.hackingwithswift.com/books/ios-swiftui/advanced-mkmapview-with-swiftui)


### PR DESCRIPTION
# Description

Added a new file / Reusable template for MapKit and MapView. Used in the PetDetailView, it takes in the pets address postcode and makes a map appear behind the pets image of their general location. If there is no address, then the original gradient should appear in the maps place.

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Using the simulator.

- [x] Test A

**Test Configuration**:
* Firmware version:
* Hardware: Mac Book Pro 2016
* Toolchain:
* SDK: Xcode

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules