### PR TITLE
Post code validation 

### DIFF
--- a/Petulia/Views/Home/FilterBarView.swift
+++ b/Petulia/Views/Home/FilterBarView.swift
@@ -30,7 +30,7 @@ struct FilterBarView: View {
                   })
           .font(.headline)
           .multilineTextAlignment(.center)
-          .keyboardType(.numbersAndPunctuation)
+          .keyboardType(.numberPad)
           .disableAutocorrection(true)
           .frame(maxWidth: 100)
           .padding(.vertical, 8)


### PR DESCRIPTION
# Description
This simply changes the type of keyboard the user sees when the postcode textfield becomes active. This is to ensure the user only types in a number for the postcode field. This fixes issue #10 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested via the use of the simulator and hands on testing.

- [x] Test A

**Test Configuration**:
* Firmware version: 
* Hardware: 
* Toolchain: -- 


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules